### PR TITLE
allow for user trusted custom CA

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -17,6 +17,12 @@
   -->
 
 <network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="false">ehtracker.org</domain>
     </domain-config>


### PR DESCRIPTION
允许APP信任由用户安装的自签证书。这并不代表信任全部自签证书，仅信任用户手动安装到系统的自签证书。