### PR TITLE
Replace hosts.txt with DoH

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -167,6 +167,7 @@ dependencies {
     // https://square.github.io/okhttp/changelogs/changelog/
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp.coroutines)
+    implementation(libs.okhttp.dnsoverhttps)
 
     implementation(libs.okio.jvm)
 

--- a/app/src/main/java/com/hippo/ehviewer/EhApplication.kt
+++ b/app/src/main/java/com/hippo/ehviewer/EhApplication.kt
@@ -31,6 +31,7 @@ import coil.util.DebugLogger
 import com.hippo.ehviewer.client.EhCookieStore
 import com.hippo.ehviewer.client.EhDns
 import com.hippo.ehviewer.client.EhEngine
+import com.hippo.ehviewer.client.EhSSLSocketFactory
 import com.hippo.ehviewer.client.EhTagDatabase
 import com.hippo.ehviewer.client.data.GalleryDetail
 import com.hippo.ehviewer.coil.MergeInterceptor
@@ -47,6 +48,7 @@ import eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor
 import kotlinx.coroutines.DelicateCoroutinesApi
 import okhttp3.Cache
 import okhttp3.OkHttpClient
+import okhttp3.internal.platform.Platform
 import java.io.File
 
 class EhApplication : SceneApplication(), ImageLoaderFactory {
@@ -222,6 +224,7 @@ class EhApplication : SceneApplication(), ImageLoaderFactory {
                 cookieJar(EhCookieStore)
                 dns(EhDns)
                 proxySelector(ehProxySelector)
+                sslSocketFactory(EhSSLSocketFactory(), Platform.get().platformTrustManager())
                 addInterceptor(CloudflareInterceptor(application))
             }.build()
         }

--- a/app/src/main/java/com/hippo/ehviewer/Settings.kt
+++ b/app/src/main/java/com/hippo/ehviewer/Settings.kt
@@ -176,8 +176,8 @@ object Settings {
     private val DEFAULT_PROXY_IP: String? = null
     private const val KEY_PROXY_PORT = "proxy_port"
     private const val DEFAULT_PROXY_PORT = -1
-    private const val KEY_BUILT_IN_HOSTS = "built_in_hosts_2"
-    private const val DEFAULT_BUILT_IN_HOSTS = false
+    private const val KEY_DOH = "dns_over_https"
+    private const val DEFAULT_DOH = false
     private const val KEY_USER_AGENT = "user_agent"
     private const val KEY_APP_LINK_VERIFY_TIP = "app_link_verify_tip"
     private const val DEFAULT_APP_LINK_VERIFY_TIP = false
@@ -663,8 +663,8 @@ object Settings {
         putInt(KEY_PROXY_PORT, value)
     }
 
-    val builtInHosts: Boolean
-        get() = getBoolean(KEY_BUILT_IN_HOSTS, DEFAULT_BUILT_IN_HOSTS)
+    val doH: Boolean
+        get() = getBoolean(KEY_DOH, DEFAULT_DOH)
 
     val userAgent: String?
         get() = getString(KEY_USER_AGENT, CHROME_USER_AGENT)

--- a/app/src/main/java/com/hippo/ehviewer/client/EhDns.kt
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhDns.kt
@@ -15,126 +15,65 @@
  */
 package com.hippo.ehviewer.client
 
-import com.hippo.ehviewer.EhApplication
-import com.hippo.ehviewer.Hosts
 import com.hippo.ehviewer.Settings
 import okhttp3.Dns
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import okhttp3.internal.platform.Platform
 import java.net.InetAddress
+import java.net.Proxy
 import java.net.UnknownHostException
 
 object EhDns : Dns {
-    private val hosts = EhApplication.hosts
-    private val builtInHosts: MutableMap<String, List<InetAddress>> = mutableMapOf()
+    private val dnsIP = listOf(
+        InetAddress.getByName("162.159.36.1"),
+        InetAddress.getByName("162.159.46.1"),
+        // https://r.android.com/1756590
+        InetAddress.getByName("104.16.248.249"),
+        InetAddress.getByName("104.16.249.249"),
+        InetAddress.getByName("2606:4700::6810:f8f9"),
+        InetAddress.getByName("2606:4700::6810:f9f9"),
+    )
+    private val dnsClient = OkHttpClient.Builder().apply {
+        proxy(Proxy.NO_PROXY)
+        sslSocketFactory(EhSSLSocketFactory(), Platform.get().platformTrustManager())
+    }.build()
+    private val doh = DnsOverHttps.Builder().apply {
+        client(dnsClient)
+        url("https://cloudflare-dns.com/dns-query".toHttpUrl())
+        bootstrapDnsHosts(dnsIP)
+        resolvePrivateAddresses(true)
+    }.build()
 
-    init {
-        /* Pair(ip: String!, blockedByCCP: Boolean!) */
-        val ehHosts = arrayOf(
-            Pair("104.20.18.168", false),
-            Pair("104.20.19.168", false),
-            Pair("172.67.2.238", false),
-        )
-        val ehgtHosts = arrayOf(
-            Pair("81.171.10.48", false),
-            Pair("178.162.139.24", false),
-            Pair("62.112.8.21", false),
-            Pair("89.39.106.43", false),
-            Pair("109.236.85.28", false),
-            Pair("2a00:7c80:0:123::3a85", false),
-            Pair("2a00:7c80:0:12d::38a1", false),
-            Pair("2a00:7c80:0:13b::37a4", false),
-        )
-        val exHosts = arrayOf(
-            Pair("178.175.128.251", false),
-            Pair("178.175.128.252", false),
-            Pair("178.175.128.253", false),
-            Pair("178.175.128.254", false),
-            Pair("178.175.129.251", false),
-            Pair("178.175.129.252", false),
-            Pair("178.175.129.253", false),
-            Pair("178.175.129.254", false),
-            Pair("178.175.132.19", false),
-            Pair("178.175.132.20", false),
-            Pair("178.175.132.21", false),
-            Pair("178.175.132.22", false),
-        )
-
-        put(
-            "e-hentai.org",
-            *ehHosts,
-        )
-        put(
-            "forums.e-hentai.org",
-            *ehHosts,
-        )
-        put(
-            "repo.e-hentai.org",
-            *ehHosts,
-        )
-        put(
-            "api.e-hentai.org",
-            *ehHosts,
-            Pair("5.79.104.110", false),
-            Pair("37.48.81.204", false),
-            Pair("37.48.92.161", false),
-            Pair("212.7.200.104", false),
-            Pair("212.7.202.51", false),
-        )
-        put(
-            "ehgt.org",
-            *ehgtHosts,
-        )
-        put(
-            "gt0.ehgt.org",
-            *ehgtHosts,
-        )
-        put(
-            "gt1.ehgt.org",
-            *ehgtHosts,
-        )
-        put(
-            "gt2.ehgt.org",
-            *ehgtHosts,
-        )
-        put(
-            "gt3.ehgt.org",
-            *ehgtHosts,
-        )
-        put(
-            "ul.ehgt.org",
-            *ehgtHosts,
-        )
-
-        put(
-            "exhentai.org",
-            *exHosts,
-        )
-        put(
-            "s.exhentai.org",
-            *exHosts,
-        )
-
-        put(
-            "raw.githubusercontent.com",
-            Pair("151.101.0.133", false),
-            Pair("151.101.64.133", false),
-            Pair("151.101.128.133", false),
-            Pair("151.101.192.133", false),
-        )
-    }
-
-    private fun put(
-        host: String,
-        vararg ips: Pair<String, Boolean>,
-    ) {
-        builtInHosts[host] = ips.mapNotNull { pair ->
-            Hosts.toInetAddress(host, pair.first)
-        }
-    }
+    // origin server IP, not cloudflare IP
+    private val exIP = listOf(
+        InetAddress.getByName("178.175.128.251"),
+        InetAddress.getByName("178.175.128.252"),
+        InetAddress.getByName("178.175.128.253"),
+        InetAddress.getByName("178.175.128.254"),
+        InetAddress.getByName("178.175.129.251"),
+        InetAddress.getByName("178.175.129.252"),
+        InetAddress.getByName("178.175.129.253"),
+        InetAddress.getByName("178.175.129.254"),
+        InetAddress.getByName("178.175.132.19"),
+        InetAddress.getByName("178.175.132.20"),
+        InetAddress.getByName("178.175.132.21"),
+        InetAddress.getByName("178.175.132.22"),
+    )
 
     @Throws(UnknownHostException::class)
     override fun lookup(hostname: String): List<InetAddress> {
-        val address = hosts[hostname] ?: builtInHosts[hostname].takeIf { Settings.builtInHosts }
-            ?: Dns.SYSTEM.lookup(hostname)
-        return address.shuffled()
+        if (!Settings.doH) {
+            return Dns.SYSTEM.lookup(hostname)
+        }
+        if (hostname == "exhentai.org" || hostname.endsWith(".exhentai.org")) {
+            return exIP.shuffled()
+        }
+        try {
+            return doh.lookup(hostname)
+        } catch (e: UnknownHostException) {
+            return Dns.SYSTEM.lookup(hostname)
+        }
     }
 }

--- a/app/src/main/java/com/hippo/ehviewer/client/EhSSLSocketFactory.kt
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhSSLSocketFactory.kt
@@ -1,0 +1,63 @@
+package com.hippo.ehviewer.client
+
+import com.hippo.ehviewer.Settings
+import java.net.InetAddress
+import java.net.Socket
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+class EhSSLSocketFactory : SSLSocketFactory() {
+    private val factory: SSLSocketFactory
+
+    init {
+        val context = SSLContext.getInstance("TLS")
+        context.init(null, null, null)
+        factory = context.socketFactory
+    }
+
+    override fun createSocket(s: Socket?, host: String?, port: Int, autoClose: Boolean): Socket {
+        val socket = factory.createSocket(s, host, port, autoClose) as SSLSocket
+        if (!Settings.doH) return socket
+        val params = socket.sslParameters
+        params.serverNames = listOf(SNIHostName("eh"))
+        socket.sslParameters = params
+        return socket
+    }
+
+    override fun createSocket(host: String?, port: Int): Socket {
+        return factory.createSocket(host, port)
+    }
+
+    override fun createSocket(
+        host: String?,
+        port: Int,
+        localHost: InetAddress?,
+        localPort: Int
+    ): Socket {
+        return factory.createSocket(host, port, localHost, localPort)
+    }
+
+    override fun createSocket(host: InetAddress?, port: Int): Socket {
+        return factory.createSocket(host, port)
+    }
+
+    override fun createSocket(
+        address: InetAddress?,
+        port: Int,
+        localAddress: InetAddress?,
+        localPort: Int
+    ): Socket {
+        return factory.createSocket(address, port, localAddress, localPort)
+    }
+
+    override fun getDefaultCipherSuites(): Array<String> {
+        return factory.defaultCipherSuites
+    }
+
+    override fun getSupportedCipherSuites(): Array<String> {
+        return factory.supportedCipherSuites
+    }
+
+}

--- a/app/src/main/java/com/hippo/ehviewer/ui/fragment/BasePreferenceFragment.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/fragment/BasePreferenceFragment.kt
@@ -60,7 +60,6 @@ open class BasePreferenceFragment :
             "mytags" -> MyTagsFragment()
             "filter" -> FilterFragment()
             "security" -> SetSecurityFragment()
-            "hosts" -> HostsFragment()
             else -> null
         }
         fragment?.let {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -384,10 +384,8 @@
     <string name="settings_advanced_read_cache_size">閲覧キャッシュのサイズ</string>
     <string name="settings_advanced_app_language_title">アプリ言語（Language）</string>
     <string name="settings_advanced_proxy">プロキシ</string>
-    <string name="settings_advanced_built_in_hosts_title">既定hosts.txt</string>
-    <string name="settings_advanced_built_in_hosts_summary">ホストをアプリ既定のIPにマッピング\nカスタムhosts.txtに上書きされます。</string>
-    <string name="settings_advanced_custom_hosts_title">カスタムhosts.txt</string>
-    <string name="settings_advanced_custom_hosts_summary">ホスト名をIPにマッピング\n既定のhosts.txtを上書きできます。</string>
+    <string name="settings_advanced_dns_over_http_title">DNS over HTTPS</string>
+    <string name="settings_advanced_dns_over_http_summary">一部の国で DNS キャッシュポイズニングから守ります</string>
     <string name="settings_advanced_export_data">データをエクスポート</string>
     <string name="settings_advanced_export_data_summary">ダウンロードリストやクイック検索などのデータを外部ストレージにエクスポートします</string>
     <string name="settings_advanced_export_data_to">データを%sにエクスポート</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -511,10 +511,8 @@
     <string name="settings_advanced_read_cache_size">阅读缓存大小</string>
     <string name="settings_advanced_app_language_title">App 界面语言</string>
     <string name="settings_advanced_proxy">代理</string>
-    <string name="settings_advanced_built_in_hosts_title">内置 hosts.txt</string>
-    <string name="settings_advanced_built_in_hosts_summary">应用提供的主机到 IP 的映射\n可被自定义 hosts.txt 覆盖</string>
-    <string name="settings_advanced_custom_hosts_title">自定义 hosts.txt</string>
-    <string name="settings_advanced_custom_hosts_summary">将主机名称映射到相应的 IP 地址\n可覆盖内置 hosts.txt</string>
+    <string name="settings_advanced_dns_over_http_title">安全 DNS（DoH）</string>
+    <string name="settings_advanced_dns_over_http_summary">解决某些地区的 DNS 污染问题</string>
     <string name="settings_advanced_backup_favorite">备份收藏列表</string>
     <string name="settings_advanced_backup_favorite_summary">备份云端收藏列表到本地</string>
     <string name="settings_advanced_backup_favorite_start">正在备份收藏列表 %s</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -511,10 +511,8 @@
     <string name="settings_advanced_read_cache_size">閲讀緩存大小</string>
     <string name="settings_advanced_app_language_title">App 界面語言</string>
     <string name="settings_advanced_proxy">代理</string>
-    <string name="settings_advanced_built_in_hosts_title">內置 hosts.txt</string>
-    <string name="settings_advanced_built_in_hosts_summary">應用提供的主機到 IP 的映射\n可被自定義 hosts.txt 覆蓋</string>
-    <string name="settings_advanced_custom_hosts_title">自定義 hosts.txt</string>
-    <string name="settings_advanced_custom_hosts_summary">將主機名稱映射到相應的 IP 地址\n可覆蓋內置 hosts.txt</string>
+    <string name="settings_advanced_dns_over_http_title">安全化的網域解析(DoH)</string>
+    <string name="settings_advanced_dns_over_http_summary">解決某些地區的 DNS 中毒問題</string>
     <string name="settings_advanced_backup_favorite">備份收藏列表</string>
     <string name="settings_advanced_backup_favorite_summary">備份雲端收藏列表到本地</string>
     <string name="settings_advanced_backup_favorite_start">正在備份收藏列表 %s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -511,10 +511,8 @@
     <string name="settings_advanced_read_cache_size">閱讀快取大小</string>
     <string name="settings_advanced_app_language_title">App 介面語言</string>
     <string name="settings_advanced_proxy">代理</string>
-    <string name="settings_advanced_built_in_hosts_title">內建 hosts.txt</string>
-    <string name="settings_advanced_built_in_hosts_summary">應用提供的主機到 IP 的對映\n可被自定義 hosts.txt 覆蓋</string>
-    <string name="settings_advanced_custom_hosts_title">自定義 hosts.txt</string>
-    <string name="settings_advanced_custom_hosts_summary">將主機名稱對映到相應的 IP 位址\n可覆蓋內建 hosts.txt</string>
+    <string name="settings_advanced_dns_over_http_title">安全化的網域解析(DoH)</string>
+    <string name="settings_advanced_dns_over_http_summary">解決某些地區的 DNS 中毒問題</string>
     <string name="settings_advanced_backup_favorite">備份收藏列表</string>
     <string name="settings_advanced_backup_favorite_summary">備份雲端收藏列表到本機</string>
     <string name="settings_advanced_backup_favorite_start">正在備份收藏列表 %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,10 +539,8 @@
     <string name="settings_advanced_proxy">Proxy</string>
     <string name="settings_advanced_proxy_summary_1" translatable="false">%1$s %2$s:%3$d</string>
     <string name="settings_advanced_proxy_summary_2" translatable="false">%1$s</string>
-    <string name="settings_advanced_built_in_hosts_title">Built-in hosts.txt</string>
-    <string name="settings_advanced_built_in_hosts_summary">Apply the built-in host-to-IP mapping provided by the app.\nIt can be overridden by custom hosts.txt</string>
-    <string name="settings_advanced_custom_hosts_title">Custom hosts.txt</string>
-    <string name="settings_advanced_custom_hosts_summary">Map hostnames to IP addresses.\nIt can override built-in hosts.txt</string>
+    <string name="settings_advanced_dns_over_http_title">DNS over HTTPS</string>
+    <string name="settings_advanced_dns_over_http_summary">Workaround DNS poisoning in some nations.</string>
     <string name="settings_advanced_user_agent_title" translatable="false">User Agent</string>
     <string name="settings_advanced_backup_favorite">Backup favorite list</string>
     <string name="settings_advanced_backup_favorite_summary">Backup remote favorite list to local</string>

--- a/app/src/main/res/xml/advanced_settings.xml
+++ b/app/src/main/res/xml/advanced_settings.xml
@@ -62,15 +62,9 @@
 
     <SwitchPreferenceCompat
         android:defaultValue="false"
-        android:key="built_in_hosts_2"
-        android:summary="@string/settings_advanced_built_in_hosts_summary"
-        android:title="@string/settings_advanced_built_in_hosts_title"
-        app:iconSpaceReserved="false" />
-
-    <Preference
-        android:key="hosts"
-        android:summary="@string/settings_advanced_custom_hosts_summary"
-        android:title="@string/settings_advanced_custom_hosts_title"
+        android:key="dns_over_https"
+        android:summary="@string/settings_advanced_dns_over_http_summary"
+        android:title="@string/settings_advanced_dns_over_http_title"
         app:iconSpaceReserved="false" />
 
     <com.hippo.ehviewer.preference.UserAgentPreference

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,7 @@ material = { module = "com.google.android.material:material", version.ref = "goo
 
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp3" }
 okhttp-coroutines = { module = "com.squareup.okhttp3:okhttp-coroutines" }
+okhttp-dnsoverhttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps" }
 okio-jvm = { module = "com.squareup.okio:okio-jvm", version.ref = "okio" }
 
 r8 = { module = "com.android.tools:r8", version.ref = "android-tools-r8" }


### PR DESCRIPTION
为避免反复更新eh的动态cf IP，更换为使用cf doh；ex站则直接使用源服务器IP。
为正常连接cf doh，使用其TLS证书内硬编码的IP和AOSP DNS解析器内硬编码的IP，并且自定义SNI。
经测试可以正常工作。
另外，为最小化修改，hosts相关代码没有完全删除，仅删除了代码入口点。