### PR TITLE
Fix image loading stuck after clearing cache

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryDetailScene.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryDetailScene.kt
@@ -440,6 +440,7 @@ class GalleryDetailScene :
                             if (mGalleryDetail == null) {
                                 return false
                             }
+                            SpiderQueen.reset(mGalleryDetail!!.gid)
                             (0..<mGalleryDetail!!.pages).forEach {
                                 val key = getImageKey(mGalleryDetail!!.gid, it)
                                 imageCache.remove(key)


### PR DESCRIPTION
解决在画廊详情页点击清除图片缓存后，快速点击阅读可能导致被清除的页加载卡住的问题